### PR TITLE
Fix a texture name in clouds demo

### DIFF
--- a/demo/shaders/clouds/cloudShader2.xml
+++ b/demo/shaders/clouds/cloudShader2.xml
@@ -29,5 +29,5 @@
   <uniformSampler name="Phase1" texture="Mie-RGB"/>
   <uniformSampler name="Phase2" texture="Mie-Lum"/>
   <uniformSampler name="BlurredTransp" texture="Mie-TransBlur"/>
-  <uniformSampler name="Params" texture="Params"/>
+  <uniformSampler name="Params" texture="params"/>
 </module>


### PR DESCRIPTION
On Unix-like systems file names are case-sensitive, while original name had case ignored (`Params.raw` vs `params.raw`).